### PR TITLE
Update to latest peasant, remove some deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "eslint": "^1.3.1",
-    "eslint-config-airbnb": "0.0.8",
-    "peasant": "^0.3.1"
+    "peasant": "^0.5.0"
   },
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT"


### PR DESCRIPTION
@pksunkara after our conversation earlier I thought about a way to remove the ESLint external deps and found a way to make it all work including support in text editors for live linting. This updates the `package.json` to remove the deps and depend on the latest Peasant. It's working here and in the `minim-parse-result` package both locally and on the CI hosts.