### PR TITLE
Add all supported Node.js versions to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-- iojs
+- '4'
+- '3'
+- '2'
+- '1'
 - '0.12'
 - '0.10'
 script:


### PR DESCRIPTION
As discussed on Slack with @pksunkara, this just adds all the currently supported/maintained Node.js versions to be tested on Travis.