### PR TITLE
Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 
 .DS_Store
 coverage
+.eslintcache

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ circle.yml
 coverage
 .vagrant
 .npmignore
+.eslintcache

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# 0.1.2 - 2015-09-24
+
+- Documentation updates
+- Fix handling of Category attribute `meta`, which is a refracted element.
+
 # 0.1.1 - 2015-09-07
 
 - Update build system to use [Peasant](https://github.com/danielgtaylor/peasant)

--- a/README.md
+++ b/README.md
@@ -6,27 +6,13 @@ This library provides an interface to the [Refract API Description namespace](ht
 
 It extends upon the base types as defined in [Minim](https://github.com/refractproject/minim).
 
-## Elements
-
-* Category
-* Copy
-* DataStructure
-* Resource
-* Transition
-* HttpTransaction
-* HttpRequest
-* HttpResponse
-* Asset
-* HrefVariables
-* HttpHeaders
-
 ## Install
 
 ```sh
 npm install minim-api-description
 ```
 
-## Usage
+## Usage Example
 
 ```js
 import minim from 'minim';
@@ -42,4 +28,433 @@ let api = namespace.fromCompactRefract(compactRefract);
 // Initialize elements directly
 const Category = namespace.getElementClass('category');
 let category = new Category();
+```
+
+## Element Reference
+
+### Category ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+A grouping element to hold other elements.
+
+#### Properties
+
+##### category.copy
+Get an array element of all child elements with the element name `copy`. This property is **ready-only**.
+
+```js
+let copy = category.copy;
+```
+
+##### category.dataStructures
+Get an array element of all child elements with the element name `category` and a class name `dataStructures`. This property is **ready-only**.
+
+```js
+let dataStructures = category.dataStructures;
+```
+
+##### category.resources
+Get an array element of all child elements with the element name `resource`. This property is **ready-only**.
+
+```js
+let resources = category.resources;
+```
+
+##### category.resourceGroups
+Get an array element of all child elements with the element name `category` and a class name `resourceGroup`. This property is **ready-only**.
+
+```js
+let groups = category.resourceGroups;
+```
+
+##### category.scenarios
+Get an array element of all child elements with a class name `scenario`. This property is **ready-only**.
+
+```js
+let scenarios = category.scenarios;
+```
+
+##### category.transitions
+Get an array element of all child elements with the element name `transition`. This property is **ready-only**.
+
+```js
+let transitions = category.transitions;
+```
+
+##### category.transitionGroups
+Get an array element of all child elements with the element name `category` and a class name `transitions`. This property is **ready-only**.
+
+```js
+let groups = category.transitionGroups;
+```
+
+### Copy ([StringElement](https://github.com/refractproject/minim#stringelement))
+An element that contains copy text used to describe elements in the API Description namespace. The element's content contains the text:
+
+```js
+console.log(`Description: ${copy.toValue()}`);
+```
+
+#### Properties
+
+##### copy.contentType
+The optional content-type of the element's content.
+
+```js
+// Get the content-type
+console.log(copy.contentType);
+
+// Set the content-type
+copy.contentType = 'text/markdown';
+```
+
+### DataStructure ([ObjectElement](https://github.com/refractproject/minim#objectelement))
+This element describes a data structure.
+
+### Resource ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+
+#### Properties
+
+##### resource.href
+The URL template of this resource.
+
+```js
+// Get the href
+console.log(`URL: ${resource.href}`);
+
+// Set the href
+resource.href = '/foo/{id}';
+```
+
+##### resource.hrefVariables
+The description of any variables present in the `resource.href` URL template.
+
+```js
+// Get the href variables
+console.log(resource.hrefVariables.keys());
+
+// Set the href variables
+resource.hrefVariables = {
+  id: 'foo'
+}
+```
+
+##### resource.transitions
+Get an array element of all child elements with the element name `transition`. This property is **ready-only**.
+
+```js
+for (const transition of resource.transitions) {
+  console.log(`Transition: ${transition.title}`);
+}
+```
+
+##### resource.dataStructure
+Get the first child element with the element name `dataStructure`. This property is **ready-only**.
+
+```js
+console.log(resource.dataStructure.keys());
+```
+
+### Transition ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+This element represents a resource transition.
+
+#### Properties
+
+##### transition.method
+Get the HTTP method of the transition, if there is one, by finding the first HTTP request and inspecting its method. This property is **read-only**.
+
+```js
+let method = transition.method;
+```
+
+##### transition.relation
+Defines a relationship to another resource or transition. Useful for hypermedia.
+
+```js
+// Get the relation
+console.log(`Relation: ${transition.relation}`);
+
+// Set the relation
+transition.relation = '...';
+```
+
+##### transition.href
+Overrides the resources URL template with one specific to this transition.
+
+```js
+// Get the herf
+console.log(`URL: ${transition.href}`);
+
+// Set the href
+transition.href = '/foo/{id}';
+```
+
+##### transition.computedHref
+Gets either the transition's `href` or the first transaction's request's `href` if it exists, otherwise returns `null`. This property is **read-only**.
+
+```js
+console.log(`URL: ${transition.computedHref}`);
+```
+
+##### transition.hrefVariables
+The description of any variables present in the `transition.href` URL template.
+
+```js
+// Get the href variables
+console.log(transition.hrefVariables.keys());
+
+// Set the href variables
+transition.hrefVariables = {
+  id: 'foo'
+}
+```
+
+##### transition.data
+The data structure describing the body payload for this transition.
+
+```js
+// Get the data attributes
+console.log(transition.data.toRefract());
+
+// Set the data attributes
+transition.data = minim.toElement({one: 1});
+```
+
+##### transition.contentTypes
+A list of content types supported by the transition.
+
+```js
+// Get the content types
+console.log(transition.contentTypes);
+
+// Set the content types
+transition.contentTypes = [
+  'application/json',
+  'application/yaml'
+]
+```
+
+##### transition.transactions
+An array element of HTTP transaction elements. This property is **read-only**.
+
+```js
+// Print out each transaction's HTTP request method
+for (const transaction of transition.transactions) {
+  console.log(`${transaction.request.method}`);
+}
+```
+
+### HttpTransaction ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+This element represents an HTTP transaction.
+
+#### Properties
+
+##### transaction.request
+The HTTP request component of this transaction. It returns an HttpRequest element if one has been defined. This property is **read-only**.
+
+```js
+// Get the HTTP request
+let request = transaction.request;
+```
+
+##### transaction.response
+The HTTP response component of this transaction. It returns an HttpResponse element if one has been defined. This property is **read-only**.
+
+```js
+// Get the HTTP response
+let response = transaction.response;
+```
+
+### HttpRequest ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+This element represents an HTTP request.
+
+#### Properties
+
+##### request.method
+The HTTP method of this request, e.g. `GET` or `POST`.
+
+```js
+// Get the HTTP method
+console.log(`HTTP method: ${request.method}`);
+
+// Set the HTTP method
+request.method = 'PUT';
+```
+
+##### request.href
+Overrides the resources URL template with one specific to this request.
+
+```js
+// Get the herf
+console.log(`URL: ${request.href}`);
+
+// Set the href
+request.href = '/foo/{id}';
+```
+
+##### request.headers
+The HTTP headers for this request. See also the `request.header(name)` shortcut, which will get the values for a header by name.
+
+```js
+// Get the headers element
+let headers = request.headers;
+
+// Set the headers element
+request.headers = new HttpHeaders();
+```
+
+##### request.contentType
+The computed content type of this request, either from a `Content-Type` header or from the message content. This property is **read-only**.
+
+```js
+// Get the content type
+console.log(`${request.contentType}`);
+```
+
+##### request.dataStructure
+The request body data structure, if it exists. This property is **read-only**.
+
+```js
+let data = request.dataStructure;
+```
+
+##### request.messageBody
+The request body content, if it exists. This property is **read-only**.
+
+```js
+// Print out the body content as a string
+console.log(`Body: ${request.messageBody}`);
+```
+
+##### request.messageBodySchema
+The request body schema, if it exists. This property is **read-only**.
+
+```js
+// Print out the body schema as a string
+console.log(`Schema: ${request.messageBodySchema}`);
+```
+
+#### Methods
+
+##### request.header(name)
+Get a case-insensitive header by name. This returns a **list of strings**, because headers can be defined multiple times.
+
+```js
+// Get the content type header
+let type = request.header('Content-Type')[0];
+```
+
+### HttpResponse ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+This element represents an HTTP response.
+
+#### Properties
+
+##### response.statusCode
+The HTTP status code, e.g. `200` or `404`.
+
+```js
+// Get the status code
+console.log(`Code: ${response.statusCode}`);
+
+// Set the status code
+response.statusCode = 400;
+```
+
+##### response.headers
+The HTTP headers for this response. See also the `response.header(name)` shortcut, which will get the values for a header by name.
+
+```js
+// Get the headers element
+let headers = response.headers;
+
+// Set the headers element
+response.headers = new HttpHeaders();
+```
+
+##### response.contentType
+The computed content type of this response, either from a `Content-Type` header or from the message content. This property is **read-only**.
+
+```js
+// Get the content type
+console.log(`${response.contentType}`);
+```
+
+##### response.dataStructure
+The response body data structure, if it exists. This property is **read-only**.
+
+```js
+let data = response.dataStructure;
+```
+
+##### response.messageBody
+The response body content, if it exists. This property is **read-only**.
+
+```js
+// Print out the body content as a string
+console.log(`Body: ${response.messageBody}`);
+```
+
+##### response.messageBodySchema
+The response body schema, if it exists. This property is **read-only**.
+
+```js
+// Print out the body schema as a string
+console.log(`Schema: ${response.messageBodySchema}`);
+```
+
+#### Methods
+
+##### response.header(name)
+Get a case-insensitive header by name. This returns a **list of strings**, because headers can be defined multiple times.
+
+```js
+// Get the content type header
+let type = response.header('Content-Type')[0];
+```
+
+### Asset (Element)
+This element represents an HTTP message payload or schema asset.
+
+#### Properties
+
+##### asset.contentType
+The content type of this asset, e.g. `application/json`.
+
+```js
+// Get the content type
+console.log(`Type: ${asset.contentType}`);
+
+// Set the content type
+asset.contentType = 'application/yaml';
+```
+
+##### asset.href
+A link to this asset.
+
+```js
+// Get the link
+console.log(`Location: ${asset.href}`);
+
+// Set the link
+asset.href = '/path/to/asset'
+```
+
+### HrefVariables ([ObjectElement](https://github.com/refractproject/minim#objectelement))
+This element represents a set of URI template variables.
+
+### HttpHeaders ([ArrayElement](https://github.com/refractproject/minim#arrayelement))
+This element represents a set of HTTP headers.
+
+#### Methods
+
+##### headers.include(name)
+Return a filtered array element of headers with the given case-insensitive name. Each header is a member element where the key is the header name and the value is the header value.
+
+```js
+let accept = headers.include('Accept');
+```
+
+##### headers.exclude(name)
+Return a filtered array element of headers without the given case-insensitive name. Each header is a member element where the key is the header name and the value is the header value.
+
+```js
+let filtered = headers.exclude('Content-Type');
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-api-description",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Minim API Description Namespace",
   "main": "./lib/api-description.js",
   "repository": {

--- a/src/elements/category.js
+++ b/src/elements/category.js
@@ -5,6 +5,7 @@ export default function(namespace) {
     constructor() {
       super(...arguments);
       this.element = 'category';
+      this._attributeElementKeys = ['meta'];
     }
 
     get resourceGroups() {

--- a/test/api-description.js
+++ b/test/api-description.js
@@ -52,7 +52,12 @@ describe('API description namespace', () => {
 
     beforeEach(() => {
       category = (new Category()).fromCompactRefract([
-        'category', {}, {}, [
+        'category', {classes: ['api']}, {meta: ['array', {}, {}, [
+          ['member', {classes: ['user']}, {}, {
+            key: ['string', {}, {}, 'HOST'],
+            value: ['string', {}, {}, 'https://example.com'],
+          }]],
+        ]}, [
           ['category', {classes: ['resourceGroup']}, {}, []],
           ['category', {classes: ['dataStructures']}, {}, []],
           ['category', {classes: ['scenario']}, {}, []],
@@ -66,6 +71,12 @@ describe('API description namespace', () => {
 
     it('should have element name category', () => {
       expect(category.element).to.equal('category');
+    });
+
+    it('should have host metadata', () => {
+      const meta = category.attributes.get('meta').first();
+      expect(meta.key.toValue()).to.equal('HOST');
+      expect(meta.value.toValue()).to.equal('https://example.com');
     });
 
     it('should contain a resource group', () => {


### PR DESCRIPTION
This documents all the elements, which was missing before. Also fixes the behavior of `category.attributes.get('meta')` to handle the refracted elements that will come from the parser.