### PR TITLE
Prepare release v0.1.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# 0.1.3 - 2016-01-14
+
+- Move minim to devDependency and update it to 0.13.0
+
 # 0.1.2 - 2015-09-24
 
 - Documentation updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minim-api-description",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Minim API Description Namespace",
   "main": "./lib/api-description.js",
   "repository": {
@@ -17,13 +17,13 @@
     "lint": "peasant lint"
   },
   "dependencies": {
-    "babel-runtime": "^5.8.20",
-    "minim": "^0.11.0"
+    "babel-runtime": "^5.8.20"
   },
   "devDependencies": {
     "chai": "^3.2.0",
     "coveralls": "^2.11.2",
-    "peasant": "^0.5.0"
+    "minim": "^0.13.0",
+    "peasant": "^0.5.2"
   },
   "author": "Apiary.io <support@apiary.io>",
   "license": "MIT"


### PR DESCRIPTION
This PR moves `minim` to a `devDependency` since we are not using it here. Also, `minim` needs to be a 1st level dependency if we plan on using `minim-api-description`.

```
import minim from 'minim';
import apiDescription from 'minim-api-description';
```

So, basically, the `package.json` becomes:

```
"minim": "^0.13.0",
"minim-api-description": ""
```

Thus we can safely remove `minim` here.