### PR TITLE
Consistent indentation of code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Get an array element of all child elements with the element name `member`. This 
 
 ```js
 for (const member of scheme.members) {
-	console.log(`Member: ${member.key}`)
+  console.log(`Member: ${member.key}`)
 }
 ```
 


### PR DESCRIPTION
Minor change to README to make all code examples 2-space indented.