### PR TITLE
Add element documentation coverage

### DIFF
--- a/src/elements/asset.js
+++ b/src/elements/asset.js
@@ -1,10 +1,24 @@
 export default function (namespace) {
+  /**
+   * @class Asset
+   *
+   * @param {string} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends Element
+   */
   class Asset extends namespace.Element {
     constructor(...args) {
       super(...args);
       this.element = 'asset';
     }
 
+    /**
+     * @name contentType
+     * @type StringElement
+     * @memberof Asset.prototype
+     */
     get contentType() {
       return this.attributes.get('contentType');
     }
@@ -12,7 +26,11 @@ export default function (namespace) {
     set contentType(value) {
       this.attributes.set('contentType', value);
     }
-
+    /**
+     * @name href
+     * @type StringElement
+     * @memberof Asset.prototype
+     */
     get href() {
       return this.attributes.get('href');
     }

--- a/src/elements/auth-scheme.js
+++ b/src/elements/auth-scheme.js
@@ -1,16 +1,35 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class AuthScheme
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class AuthScheme extends ArrayElement {
     constructor(...args) {
       super(...args);
       this.element = 'authScheme';
     }
 
+    /**
+     * @name transitions
+     * @type ArraySlice
+     * @memberof HttpMessagePayload.prototype
+     */
     get transitions() {
       return this.children.filter(item => item.element === 'transition');
     }
 
+    /**
+     * @name members
+     * @type ArraySlice
+     * @memberof HttpMessagePayload.prototype
+     */
     get members() {
       return this.children.filter(item => item.element === 'member');
     }

--- a/src/elements/category.js
+++ b/src/elements/category.js
@@ -1,16 +1,35 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class Category
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class Category extends ArrayElement {
     constructor(...args) {
       super(...args);
       this.element = 'category';
     }
 
+    /**
+     * @name resourceGroups
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get resourceGroups() {
       return this.children.filter(item => item.classes.contains('resourceGroup'));
     }
 
+    /**
+     * @name dataStructures
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get dataStructures() {
       return this.children.filter(item => item.classes.contains('dataStructures'));
     }
@@ -23,18 +42,38 @@ export default function (namespace) {
       return this.children.filter(item => item.classes.contains('transitions'));
     }
 
+    /**
+     * @name authSchemes
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get authSchemeGroups() {
       return this.children.filter(item => item.classes.contains('authSchemes'));
     }
 
+    /**
+     * @name resources
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get resources() {
       return this.children.filter(item => item.element === 'resource');
     }
 
+    /**
+     * @name transitions
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get transitions() {
       return this.children.filter(item => item.element === 'transition');
     }
 
+    /**
+     * @name authSchemes
+     * @type ArraySlice
+     * @memberof Category.prototype
+     */
     get authSchemes() {
       const schemes = ['Basic Authentication Scheme', 'Token Authentication Scheme', 'OAuth2 Scheme'];
       return this.children.filter(item => schemes.indexOf(item.element) !== -1);

--- a/src/elements/copy.js
+++ b/src/elements/copy.js
@@ -2,6 +2,11 @@ export default function (namespace) {
   const StringElement = namespace.getElementClass('string');
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @name copy
+   * @type Copy
+   * @memberof Element.prototype
+   */
   if (!Object.getOwnPropertyNames(ArrayElement.prototype).includes('copy')) {
     Object.defineProperty(ArrayElement.prototype, 'copy', {
       get() {
@@ -10,12 +15,26 @@ export default function (namespace) {
     });
   }
 
+  /**
+   * @class Copy
+   *
+   * @param {string} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends StringElement
+   */
   class Copy extends StringElement {
     constructor(...args) {
       super(...args);
       this.element = 'copy';
     }
 
+    /**
+     * @name contentType
+     * @type StringElement
+     * @memberof Copy.prototype
+     */
     get contentType() {
       return this.attributes.get('contentType');
     }

--- a/src/elements/data-structure.js
+++ b/src/elements/data-structure.js
@@ -1,4 +1,13 @@
 export default function (namespace) {
+  /**
+   * @class DataStructure
+   *
+   * @param {Element} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends Element
+   */
   class DataStructure extends namespace.Element {
     constructor(...args) {
       super(...args);

--- a/src/elements/enum.js
+++ b/src/elements/enum.js
@@ -1,12 +1,26 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class Enum
+   *
+   * @param {Element} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends Element
+   */
   class Enum extends namespace.Element {
     constructor(content, meta, attributes) {
       super(namespace.toElement(content), meta, attributes);
       this.element = 'enum';
     }
 
+    /**
+     * @name enumerations
+     * @type ArrayElement
+     * @memberof Enum.prototype
+     */
     get enumerations() {
       return this.attributes.get('enumerations');
     }

--- a/src/elements/href-variables.js
+++ b/src/elements/href-variables.js
@@ -1,6 +1,15 @@
 export default function (namespace) {
   const ObjectElement = namespace.getElementClass('object');
 
+  /**
+   * @class HrefVariables
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ObjectElement
+   */
   class HrefVariables extends ObjectElement {
     constructor(...args) {
       super(...args);

--- a/src/elements/http-headers.js
+++ b/src/elements/http-headers.js
@@ -1,6 +1,15 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class HttpHeaders
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class HttpHeaders extends ArrayElement {
     constructor(...args) {
       super(...args);

--- a/src/elements/http-message-payload.js
+++ b/src/elements/http-message-payload.js
@@ -4,7 +4,21 @@ import httpResponse from './http-response';
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class HttpMessagePayload
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class HttpMessagePayload extends ArrayElement {
+    /**
+     * @name headers
+     * @type HttpHeaders
+     * @memberof HttpMessagePayload.prototype
+     */
     get headers() {
       return this.attributes.get('headers');
     }
@@ -24,6 +38,11 @@ export default function (namespace) {
       return header;
     }
 
+    /**
+     * @name contentType
+     * @type StringElement
+     * @memberof HttpMessagePayload.prototype
+     */
     get contentType() {
       const header = this.header('Content-Type');
 
@@ -34,16 +53,31 @@ export default function (namespace) {
       return this.content && this.content.contentType;
     }
 
+    /**
+     * @name dataStructure
+     * @type Asset
+     * @memberof HttpMessagePayload.prototype
+     */
     get dataStructure() {
       return this.findByElement('dataStructure').first;
     }
 
+    /**
+     * @name messageBody
+     * @type Asset
+     * @memberof HttpMessagePayload.prototype
+     */
     get messageBody() {
       // Returns the *first* message body. Only one should be defined according
       // to the spec, but it's possible to include more.
       return this.filter(item => item.element === 'asset' && item.classes.contains('messageBody')).first;
     }
 
+    /**
+     * @name messageBodySchema
+     * @type Asset
+     * @memberof HttpMessagePayload.prototype
+     */
     get messageBodySchema() {
       // Returns the *first* message body schema. Only one should be defined
       // according to the spec, but it's possible to include more.

--- a/src/elements/http-request.js
+++ b/src/elements/http-request.js
@@ -1,10 +1,24 @@
 export default function (namespace, HttpMessagePayload) {
+  /**
+   * @class HttpRequest
+   *
+   * @param content
+   * @param meta
+   * @param attributes
+   *
+   * @extends HttpMessagePayload
+   */
   class HttpRequest extends HttpMessagePayload {
     constructor(...args) {
       super(...args);
       this.element = 'httpRequest';
     }
 
+    /**
+     * @name method
+     * @type StringElement
+     * @memberof HttpRequest.prototype
+     */
     get method() {
       return this.attributes.get('method');
     }
@@ -13,6 +27,11 @@ export default function (namespace, HttpMessagePayload) {
       this.attributes.set('method', value);
     }
 
+    /**
+     * @name href
+     * @type StringElement
+     * @memberof HttpRequest.prototype
+     */
     get href() {
       return this.attributes.get('href');
     }

--- a/src/elements/http-response.js
+++ b/src/elements/http-response.js
@@ -1,10 +1,24 @@
 export default function (namespace, HttpMessagePayload) {
+  /**
+   * @class HttpResponse
+   *
+   * @param content
+   * @param meta
+   * @param attributes
+   *
+   * @extends HttpMessagePayload
+   */
   class HttpResponse extends HttpMessagePayload {
     constructor(...args) {
       super(...args);
       this.element = 'httpResponse';
     }
 
+    /**
+     * @name statusCode
+     * @type NumberElement
+     * @memberof HttpResponse.prototype
+     */
     get statusCode() {
       return this.attributes.get('statusCode');
     }

--- a/src/elements/http-transaction.js
+++ b/src/elements/http-transaction.js
@@ -1,20 +1,44 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class HttpTransaction
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class HttpTransaction extends ArrayElement {
     constructor(...args) {
       super(...args);
       this.element = 'httpTransaction';
     }
 
+    /**
+     * @name request
+     * @type HttpRequest
+     * @memberof HttpTransaction.prototype
+     */
     get request() {
       return this.children.filter(item => item.element === 'httpRequest').first;
     }
 
+    /**
+     * @name response
+     * @type HttpResponse
+     * @memberof HttpTransaction.prototype
+     */
     get response() {
       return this.children.filter(item => item.element === 'httpResponse').first;
     }
 
+    /**
+     * @name authSchemes
+     * @type ArrayElement
+     * @memberof HttpTransaction.prototype
+     */
     get authSchemes() {
       return this.attributes.get('authSchemes');
     }

--- a/src/elements/resource.js
+++ b/src/elements/resource.js
@@ -1,6 +1,15 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class Resource
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class Resource extends ArrayElement {
     constructor(...args) {
       super(...args);
@@ -8,6 +17,11 @@ export default function (namespace) {
       this.element = 'resource';
     }
 
+    /**
+     * @name href
+     * @type StringElement
+     * @memberof Resource.prototype
+     */
     get href() {
       return this.attributes.get('href');
     }
@@ -16,6 +30,11 @@ export default function (namespace) {
       this.attributes.set('href', value);
     }
 
+    /**
+     * @name hrefVariables
+     * @type HrefVariables
+     * @memberof Resource.prototype
+     */
     get hrefVariables() {
       return this.attributes.get('hrefVariables');
     }
@@ -24,10 +43,20 @@ export default function (namespace) {
       this.attributes.set('hrefVariables', value);
     }
 
+    /**
+     * @name transitions
+     * @type ArraySlice
+     * @memberof Resource.prototype
+     */
     get transitions() {
       return this.children.filter(item => item.element === 'transition');
     }
 
+    /**
+     * @name dataStructure
+     * @type DataStructure
+     * @memberof Resource.prototype
+     */
     get dataStructure() {
       return this.children.filter(item => item.element === 'dataStructure').first;
     }

--- a/src/elements/transition.js
+++ b/src/elements/transition.js
@@ -1,6 +1,15 @@
 export default function (namespace) {
   const ArrayElement = namespace.getElementClass('array');
 
+  /**
+   * @class Transition
+   *
+   * @param {Array} content
+   * @param meta
+   * @param attributes
+   *
+   * @extends ArrayElement
+   */
   class Transition extends ArrayElement {
     constructor(...args) {
       super(...args);
@@ -8,6 +17,11 @@ export default function (namespace) {
       this.element = 'transition';
     }
 
+    /**
+     * @name method
+     * @type StringElement
+     * @memberof Transition.prototype
+     */
     get method() {
       const transaction = this.transactions.first;
 
@@ -22,6 +36,11 @@ export default function (namespace) {
       return undefined;
     }
 
+    /**
+     * @name relation
+     * @type StringElement
+     * @memberof Transition.prototype
+     */
     get relation() {
       return this.attributes.get('relation');
     }
@@ -30,6 +49,11 @@ export default function (namespace) {
       this.attributes.set('relation', value);
     }
 
+    /**
+     * @name href
+     * @type StringElement
+     * @memberof Transition.prototype
+     */
     get href() {
       return this.attributes.get('href');
     }
@@ -46,6 +70,11 @@ export default function (namespace) {
       }
     }
 
+    /**
+     * @name hrefVariables
+     * @type HrefVariables
+     * @memberof Transition.prototype
+     */
     get hrefVariables() {
       return this.attributes.get('hrefVariables');
     }
@@ -54,6 +83,11 @@ export default function (namespace) {
       this.attributes.set('hrefVariables', value);
     }
 
+    /**
+     * @name data
+     * @type DataStructure
+     * @memberof Transition.prototype
+     */
     get data() {
       return this.attributes.get('data');
     }
@@ -62,6 +96,11 @@ export default function (namespace) {
       this.attributes.set('data', value);
     }
 
+    /**
+     * @name contentTypes
+     * @type ArrayElement
+     * @memberof Transition.prototype
+     */
     get contentTypes() {
       return this.attributes.get('contentTypes');
     }
@@ -70,6 +109,11 @@ export default function (namespace) {
       this.attributes.set('contentTypes', value);
     }
 
+    /**
+     * @name transactions
+     * @type ArraySlice
+     * @memberof Transition.prototype
+     */
     get transactions() {
       return this.children.filter(item => item.element === 'httpTransaction');
     }


### PR DESCRIPTION
I've added JSDoc coverage for most elements and properties. I have skipped one or two properties for now as I believe there is some stuff that is incorrect. For example, there is a property on Category which returns "scenarios". These are not defined anywhere in API Elements so I don't want to mention it in docs at all (perhaps we should remove the property, but that's for separate discussion/PR).

```js
    get scenarios() {
      return this.children.filter(item => item.classes.contains('scenario'));
    }
```